### PR TITLE
Ft planner separate yaml wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+tempResults/

--- a/experiments/1_fabric_mpc/planarArm/setup/fabric_n2.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/fabric_n2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 2
 m_base: 1.0

--- a/experiments/1_fabric_mpc/planarArm/setup/fabric_n3.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/fabric_n3.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 3
 m_base: 1.0

--- a/experiments/1_fabric_mpc/planarArm/setup/fabric_n5.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/fabric_n5.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/experiments/1_fabric_mpc/planarArm/setup/mpc_n2.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/mpc_n2.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 2
 dt: 0.5
 H: 10

--- a/experiments/1_fabric_mpc/planarArm/setup/mpc_n3.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/mpc_n3.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 3
 dt: 0.5
 H: 20

--- a/experiments/1_fabric_mpc/planarArm/setup/mpc_n5.yaml
+++ b/experiments/1_fabric_mpc/planarArm/setup/mpc_n5.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 5
 dt: 0.5
 H: 20

--- a/experiments/1_fabric_mpc/pointMass/setup/fabric.yaml
+++ b/experiments/1_fabric_mpc/pointMass/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: pointRobot
 n: 2
 m_base: 0.2

--- a/experiments/1_fabric_mpc/pointMass/setup/fabricPoint_test.yaml
+++ b/experiments/1_fabric_mpc/pointMass/setup/fabricPoint_test.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: pointRobot
 n: 2
 m_base: 0.4

--- a/experiments/1_fabric_mpc/pointMass/setup/mpc.yaml
+++ b/experiments/1_fabric_mpc/pointMass/setup/mpc.yaml
@@ -4,7 +4,7 @@ interval: 10
 n: 2
 obst:
   nbObst: 5
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 1.0

--- a/experiments/1_fabric_mpc/pointMass/setup/mpc_obst.yaml
+++ b/experiments/1_fabric_mpc/pointMass/setup/mpc_obst.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 2
 dt: 0.5
 H: 10

--- a/experiments/1_fabric_mpc/realPanda/setup/fabric.yaml
+++ b/experiments/1_fabric_mpc/realPanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/1_fabric_mpc/realPanda/setup/fabric_old.yaml
+++ b/experiments/1_fabric_mpc/realPanda/setup/fabric_old.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/1_fabric_mpc/realPanda/setup/mpc.yaml
+++ b/experiments/1_fabric_mpc/realPanda/setup/mpc.yaml
@@ -5,7 +5,7 @@ n: 7
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0

--- a/experiments/1_fabric_mpc/simMobilePanda/setup/fabric.yaml
+++ b/experiments/1_fabric_mpc/simMobilePanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simMobilePanda
 n: 10
 m_base: 1.0

--- a/experiments/1_fabric_mpc/simMobilePanda/setup/mpc.yaml
+++ b/experiments/1_fabric_mpc/simMobilePanda/setup/mpc.yaml
@@ -5,7 +5,7 @@ n: 7
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0

--- a/experiments/1_fabric_mpc/simPanda/setup/fabric.yaml
+++ b/experiments/1_fabric_mpc/simPanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/1_fabric_mpc/simPanda/setup/mpc.yaml
+++ b/experiments/1_fabric_mpc/simPanda/setup/mpc.yaml
@@ -5,7 +5,7 @@ n: 7
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0

--- a/experiments/1_fabric_mpc/simTiago/setup/fabric.yaml
+++ b/experiments/1_fabric_mpc/simTiago/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 15
 m_base: 1.0

--- a/experiments/1_fabric_mpc/simTiago/setup/mpc.yaml
+++ b/experiments/1_fabric_mpc/simTiago/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/2_static_dynamic/mobilePanda/setup/dynamicFabric.yaml
+++ b/experiments/2_static_dynamic/mobilePanda/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: mobilePanda
 n: 10
 m_base: 1.0

--- a/experiments/2_static_dynamic/mobilePanda/setup/mpc.yaml
+++ b/experiments/2_static_dynamic/mobilePanda/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/2_static_dynamic/mobilePanda/setup/staticFabric.yaml
+++ b/experiments/2_static_dynamic/mobilePanda/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: mobilePanda
 n: 10
 m_base: 1.0

--- a/experiments/2_static_dynamic/planarArm/setup/dynamicFabric_n2.yaml
+++ b/experiments/2_static_dynamic/planarArm/setup/dynamicFabric_n2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: planarArm
 n: 2
 m_base: 1.0

--- a/experiments/2_static_dynamic/planarArm/setup/dynamicFabric_n5.yaml
+++ b/experiments/2_static_dynamic/planarArm/setup/dynamicFabric_n5.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/experiments/2_static_dynamic/planarArm/setup/staticFabric_n2.yaml
+++ b/experiments/2_static_dynamic/planarArm/setup/staticFabric_n2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 2
 m_base: 1.0

--- a/experiments/2_static_dynamic/planarArm/setup/staticFabric_n5.yaml
+++ b/experiments/2_static_dynamic/planarArm/setup/staticFabric_n5.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/experiments/2_static_dynamic/pointMass/setup/dynamicFabric.yaml
+++ b/experiments/2_static_dynamic/pointMass/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: pointRobot
 n: 2
 m_base: 1.0

--- a/experiments/2_static_dynamic/pointMass/setup/staticFabric.yaml
+++ b/experiments/2_static_dynamic/pointMass/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: pointRobot
 n: 2
 m_base: 1.0

--- a/experiments/2_static_dynamic/realPanda/setup/dynamicFabric.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/2_static_dynamic/realPanda/setup/dynamicFabric2.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/dynamicFabric2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/2_static_dynamic/realPanda/setup/fabric.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/2_static_dynamic/realPanda/setup/mpc.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/2_static_dynamic/realPanda/setup/staticFabric.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/2_static_dynamic/realPanda/setup/staticFabric2.yaml
+++ b/experiments/2_static_dynamic/realPanda/setup/staticFabric2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/2_static_dynamic/simPanda/setup/dynamicFabric.yaml
+++ b/experiments/2_static_dynamic/simPanda/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 0.1

--- a/experiments/2_static_dynamic/simPanda/setup/mpc.yaml
+++ b/experiments/2_static_dynamic/simPanda/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/2_static_dynamic/simPanda/setup/staticFabric.yaml
+++ b/experiments/2_static_dynamic/simPanda/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 0.1

--- a/experiments/3_moving_obstacles/planarArm/setup/dynamicFabric_n2.yaml
+++ b/experiments/3_moving_obstacles/planarArm/setup/dynamicFabric_n2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: planarArm
 n: 2
 m_base: 0.1

--- a/experiments/3_moving_obstacles/planarArm/setup/dynamicFabric_n5.yaml
+++ b/experiments/3_moving_obstacles/planarArm/setup/dynamicFabric_n5.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/experiments/3_moving_obstacles/planarArm/setup/mpc_n2.yaml
+++ b/experiments/3_moving_obstacles/planarArm/setup/mpc_n2.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 2
 dt: 0.05
 H: 50

--- a/experiments/3_moving_obstacles/planarArm/setup/staticFabric_n2.yaml
+++ b/experiments/3_moving_obstacles/planarArm/setup/staticFabric_n2.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 2
 m_base: 0.1

--- a/experiments/3_moving_obstacles/planarArm/setup/staticFabric_n5.yaml
+++ b/experiments/3_moving_obstacles/planarArm/setup/staticFabric_n5.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/experiments/3_moving_obstacles/pointMass/setup/dynamicFabric.yaml
+++ b/experiments/3_moving_obstacles/pointMass/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: pointRobot
 n: 2
 m_base: 1.0

--- a/experiments/3_moving_obstacles/pointMass/setup/mpc.yaml
+++ b/experiments/3_moving_obstacles/pointMass/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 2
 dt: 0.10
 H: 30

--- a/experiments/3_moving_obstacles/pointMass/setup/staticFabric.yaml
+++ b/experiments/3_moving_obstacles/pointMass/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: pointRobot
 n: 2
 m_base: 1.0

--- a/experiments/3_moving_obstacles/realPanda/setup/dynamicFabric.yaml
+++ b/experiments/3_moving_obstacles/realPanda/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 0.1

--- a/experiments/3_moving_obstacles/realPanda/setup/fabric.yaml
+++ b/experiments/3_moving_obstacles/realPanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/3_moving_obstacles/realPanda/setup/mpc.yaml
+++ b/experiments/3_moving_obstacles/realPanda/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/3_moving_obstacles/realPanda/setup/staticFabric.yaml
+++ b/experiments/3_moving_obstacles/realPanda/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/3_moving_obstacles/simPanda/setup/dynamicFabric.yaml
+++ b/experiments/3_moving_obstacles/simPanda/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/3_moving_obstacles/simPanda/setup/fabric.yaml
+++ b/experiments/3_moving_obstacles/simPanda/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/3_moving_obstacles/simPanda/setup/mpc.yaml
+++ b/experiments/3_moving_obstacles/simPanda/setup/mpc.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 7
 dt: 0.5
 H: 20

--- a/experiments/3_moving_obstacles/simPanda/setup/staticFabric.yaml
+++ b/experiments/3_moving_obstacles/simPanda/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/experiments/4_non_holonomic/groundRobot/baseAndArm/setup/fabric_arm.yaml
+++ b/experiments/4_non_holonomic/groundRobot/baseAndArm/setup/fabric_arm.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: groundRobot
 n: 4
 m_base: 5.0

--- a/experiments/4_non_holonomic/realAlbert/setup/dynamicFabric.yaml
+++ b/experiments/4_non_holonomic/realAlbert/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: albert
 n: 10
 m_base: 1.5

--- a/experiments/4_non_holonomic/realAlbert/setup/fabric.yaml
+++ b/experiments/4_non_holonomic/realAlbert/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: albert
 n: 10
 m_base: 0.5

--- a/experiments/4_non_holonomic/realBoxer/setup/dynamicFabric.yaml
+++ b/experiments/4_non_holonomic/realBoxer/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: boxer
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/realBoxer/setup/fabric.yaml
+++ b/experiments/4_non_holonomic/realBoxer/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: boxer
 n: 3
 m_base: 0.1

--- a/experiments/4_non_holonomic/realBoxer/setup/fabric_dynamicObst.yaml
+++ b/experiments/4_non_holonomic/realBoxer/setup/fabric_dynamicObst.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: boxer
 n: 3
 m_base: 0.1

--- a/experiments/4_non_holonomic/realBoxer/setup/staticFabric.yaml
+++ b/experiments/4_non_holonomic/realBoxer/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: boxer
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/simAlbert/setup/fabric.yaml
+++ b/experiments/4_non_holonomic/simAlbert/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: albert
 n: 10
 m_base: 10.0

--- a/experiments/4_non_holonomic/simBase/setup/fabric.yaml
+++ b/experiments/4_non_holonomic/simBase/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: groundRobot
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/simBase/setup/fabric_real.yaml
+++ b/experiments/4_non_holonomic/simBase/setup/fabric_real.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: groundRobot
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/simBoxer/setup/dynamicFabric.yaml
+++ b/experiments/4_non_holonomic/simBoxer/setup/dynamicFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: boxer
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/simBoxer/setup/fabric.yaml
+++ b/experiments/4_non_holonomic/simBoxer/setup/fabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: boxer
 n: 3
 m_base: 1.0

--- a/experiments/4_non_holonomic/simBoxer/setup/mpc.yaml
+++ b/experiments/4_non_holonomic/simBoxer/setup/mpc.yaml
@@ -5,7 +5,7 @@ n: 3
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0

--- a/experiments/4_non_holonomic/simBoxer/setup/staticFabric.yaml
+++ b/experiments/4_non_holonomic/simBoxer/setup/staticFabric.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: boxer
 n: 3
 m_base: 1.0

--- a/experiments/example/setup/planner.yaml
+++ b/experiments/example/setup/planner.yaml
@@ -1,4 +1,4 @@
-type: pd
+name: pd
 robot_type: pointRobot
 n: 2
 k: 0.8

--- a/plannerbenchmark/exec/runner
+++ b/plannerbenchmark/exec/runner
@@ -177,7 +177,7 @@ class Runner(object):
                     qdot = ob['xdot']
                     if self._experiment.dynamic():
                         envEval = self._experiment.evaluate(t)
-                        if not planner.dynamic():
+                        if not planner.config.dynamic:
                             envEval[1] = np.zeros(envEval[1].size)
                             envEval[2] = np.zeros(envEval[2].size)
                         observation = [q, qdot] + envEval

--- a/plannerbenchmark/generic/planner.py
+++ b/plannerbenchmark/generic/planner.py
@@ -1,25 +1,25 @@
 from abc import abstractmethod
+from dataclasses import dataclass
 import yaml
 from plannerbenchmark.generic.planner_registry import PlannerRegistry
 
 class PlannerSettingIncomplete(Exception):
     pass
 
+@dataclass
+class PlannerConfig():
+    interval: int = 1
+    n: int = 2
+    name: str = 'Planner'
+    robot_type: str = 'pointRobot'
+
 class Planner(metaclass=PlannerRegistry):
-    def __init__(self, exp, setupFile, required_keys):
+    def __init__(self, exp, **kwargs):
         self._exp = exp
-        self._setupFile = setupFile
-        self._required_keys = required_keys
-        self.parseSetup()
 
     @abstractmethod
     def reset(self):
         pass
-
-    def parseSetup(self):
-        with open(self._setupFile, "r") as setupStream:
-            self._setup = yaml.safe_load(setupStream)
-        self.checkCompleteness()
 
     def plannerType(self):
         return self._setup['type']
@@ -52,6 +52,10 @@ class Planner(metaclass=PlannerRegistry):
 
     @abstractmethod
     def concretize(self):
+        pass
+
+    @abstractmethod
+    def config_as_dict(self):
         pass
 
     def save(self, folderPath):

--- a/plannerbenchmark/generic/planner.py
+++ b/plannerbenchmark/generic/planner.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 import yaml
 from plannerbenchmark.generic.planner_registry import PlannerRegistry
 
@@ -16,13 +16,18 @@ class PlannerConfig():
 class Planner(metaclass=PlannerRegistry):
     def __init__(self, exp, **kwargs):
         self._exp = exp
+        self._config = PlannerConfig()
 
     @abstractmethod
     def reset(self):
         pass
 
+    @property
+    def config(self):
+        return self._config
+
     def plannerType(self):
-        return self._setup['type']
+        return self.config.name
 
     def checkCompleteness(self):
         incomplete = False
@@ -60,7 +65,7 @@ class Planner(metaclass=PlannerRegistry):
 
     def save(self, folderPath):
         with open(folderPath + "/planner.yaml", 'w') as file:
-            yaml.dump(self._setup, file)
+            yaml.dump(asdict(self.config), file)
 
     @abstractmethod
     def computeAction(self, q, qdot):

--- a/plannerbenchmark/generic/planner_registry.py
+++ b/plannerbenchmark/generic/planner_registry.py
@@ -28,6 +28,6 @@ class PlannerRegistry(type):
     @classmethod
     def create_planner(cls, exp, setup, **kwargs):
         cls.parseSetup(setup)
-        name = cls._setup['type']
+        name = cls._setup['name']
         planner = cls.REGISTRY[name]
-        return planner(exp, setup)
+        return planner(exp, **cls._setup)

--- a/plannerbenchmark/planner/fabricPlanner.py
+++ b/plannerbenchmark/planner/fabricPlanner.py
@@ -49,12 +49,8 @@ class FabricPlanner(Planner):
     def __init__(self, exp, **kwargs):
         super().__init__(exp, **kwargs)
         self._config = FabricConfig(**kwargs)
-        self._exp = exp
         self.reset()
 
-    @property
-    def config(self):
-        return self._config
 
     def reset(self):
         if self._exp.robotType() in ['groundRobot', 'boxer', 'albert']:

--- a/plannerbenchmark/planner/fabricPlanner.py
+++ b/plannerbenchmark/planner/fabricPlanner.py
@@ -1,4 +1,6 @@
 # General dependencies
+from dataclasses import dataclass, field
+from typing import Dict
 import casadi as ca
 import numpy as np
 
@@ -27,74 +29,46 @@ from MotionPlanningEnv.dynamicSphereObstacle import DynamicSphereObstacle
 from MotionPlanningEnv.sphereObstacle import SphereObstacle
 
 # Dependencies on plannerbenchmark
-from plannerbenchmark.generic.planner import Planner
+from plannerbenchmark.generic.planner import Planner, PlannerConfig
+
+@dataclass
+class FabricConfig(PlannerConfig):
+    m_base: float = 0.2
+    m_ratio: float = 1.0
+    obst: Dict[str, float] = field(default_factory = lambda: ({'exp': 1.0, 'lam': 1.0}))
+    selfCol: Dict[str, float] = field(default_factory = lambda: ({'exp': 1.0, 'lam': 1.0}))
+    attractor: Dict[str, float] = field(default_factory = lambda: ({'k_psi': 3.0}))
+    speed: Dict[str, float] = field(default_factory = lambda : ({'ex_factor': 1.0}))
+    dynamic: bool = False
+    limits: Dict[str, float] = field(default_factory = lambda: ({'exp': 1.0, 'lam': 1.0}))
+    damper: Dict[str, object] = field(default_factory = lambda :({'r_d': 0.8, 'b': [0.1, 6.5]}))
+
 
 class FabricPlanner(Planner):
 
-    def __init__(self, exp, setupFile):
-        required_keys = [
-            "type",
-            "n",
-            "obst",
-            "attractor",
-            "speed",
-            "damper",
-            "limits",
-            "selfCol",
-            "interval",
-            "dynamic",
-        ]
-        super().__init__(exp, setupFile, required_keys)
+    def __init__(self, exp, **kwargs):
+        super().__init__(exp, **kwargs)
+        self._config = FabricConfig(**kwargs)
+        self._exp = exp
         self.reset()
+
+    @property
+    def config(self):
+        return self._config
 
     def reset(self):
         if self._exp.robotType() in ['groundRobot', 'boxer', 'albert']:
-            self._planner = DefaultNonHolonomicPlanner(self.n(), m_base=self.mBase(), m_ratio=self.m_ratio(), debug=False)
+            self._planner = DefaultNonHolonomicPlanner(self.config.n, m_base=self.config.m_base, m_ratio=self.config.m_ratio, debug=False)
         else:
-            self._planner = DefaultFabricPlanner(self.n(), m_base=self.mBase(), debug=False)
+            self._planner = DefaultFabricPlanner(self.config.n, m_base=self.config.m_base, debug=False)
         self._q, self._qdot = self._planner.var()
-
-    def m_ratio(self):
-        if 'm_ratio' in self._setup.keys():
-            return self._setup['m_ratio']
-        return 0.1
-
-    def interval(self):
-        return self._setup["interval"]
-
-    def n(self):
-        return self._setup["n"]
-
-    def mBase(self):
-        return self._setup["m_base"]
-
-    def dynamic(self):
-        return self._setup["dynamic"]
-
-    def configObst(self):
-        return self._setup["obst"]
-
-    def configSelfColAvoidance(self):
-        return self._setup["selfCol"]
-
-    def configAttractor(self):
-        return self._setup["attractor"]
-
-    def configSpeed(self):
-        return self._setup["speed"]
-
-    def configLimits(self):
-        return self._setup["limits"]
-
-    def configDamper(self):
-        return self._setup["damper"]
 
     def setObstacles(self, obsts, r_body):
         x = ca.SX.sym("x", 1)
         xdot = ca.SX.sym("xdot", 1)
         lag_col = CollisionLagrangian(x, xdot)
         geo_col = CollisionGeometry(
-            x, xdot, exp=self.configObst()["exp"], lam=self.configObst()["lam"]
+            x, xdot, exp=self.config.obst['exp'], lam=self.config.obst["lam"]
         )
         for i, obst in enumerate(obsts):
             m_obst = obst.dim()
@@ -104,7 +78,7 @@ class FabricPlanner(Planner):
                 xdot_col = ca.SX.sym("xdot_col", m_obst)
                 x_rel = ca.SX.sym("x_rel", m_obst)
                 xdot_rel = ca.SX.sym("xdot_rel", m_obst)
-            for j in range(1, self.n() + 1):
+            for j in range(1, self.config.n + 1):
                 if self._exp.robotType() == "pointRobot" and j == 1:
                     continue
                 if self._exp.robotType() == "groundRobot" and j == 1:
@@ -137,8 +111,8 @@ class FabricPlanner(Planner):
         geo_selfCol = CollisionGeometry(
             x,
             xdot,
-            exp=self.configSelfColAvoidance()["exp"],
-            lam=self.configSelfColAvoidance()["lam"],
+            exp=self.config.selfCol['exp'],
+            lam=self.config.selfCol['lam'],
         )
         for pair in self._exp.selfCollisionPairs():
             fk_1 = self._exp.fk(self._q, pair[0], positionOnly=True)
@@ -151,9 +125,9 @@ class FabricPlanner(Planner):
         xdot = ca.SX.sym("xdot", 1)
         lag_col = CollisionLagrangian(x, xdot)
         geo_col = LimitGeometry(
-            x, xdot, lam=self.configLimits()["lam"], exp=self.configLimits()["exp"],
+            x, xdot, lam=self.config.limits["lam"], exp=self.config.limits["exp"],
         )
-        for i in range(self.n()):
+        for i in range(self.config.n):
             dm_col = UpperLimitMap(self._q, self._qdot, limits[1][i], i)
             self._planner.addGeometry(dm_col, lag_col, geo_col)
             dm_col = LowerLimitMap(self._q, self._qdot, limits[0][i], i)
@@ -170,13 +144,13 @@ class FabricPlanner(Planner):
             if subGoal.type() == "analyticSubGoal":
                 goalSymbolicTraj = AnalyticSymbolicTrajectory(ca.SX(np.identity(subGoal.m())), subGoal.m(), traj=subGoal.traj())
                 dm_psi, lag_psi, geo_psi, x_psi, xdot_psi = defaultDynamicAttractor(
-                    self._q, self._qdot, fk, goalSymbolicTraj, k_psi=self.configAttractor()['k_psi'] * subGoal.weight()
+                    self._q, self._qdot, fk, goalSymbolicTraj, k_psi=self.config.attractor['k_psi'] * subGoal.weight()
                 )
                 self._planner.addForcingGeometry(dm_psi, lag_psi, geo_psi, goalVelocity=goalSymbolicTraj.xdot())
             elif subGoal.type() == "splineSubGoal": 
                 goalSymbolicTraj = AnalyticSymbolicTrajectory(ca.SX(np.identity(subGoal.m())), subGoal.m(), traj=subGoal.traj())
                 dm_psi, lag_psi, geo_psi, x_psi, xdot_psi = defaultDynamicAttractor(
-                    self._q, self._qdot, fk, goalSymbolicTraj, k_psi=self.configAttractor()['k_psi'] * subGoal.weight()
+                    self._q, self._qdot, fk, goalSymbolicTraj, k_psi=self.config.attractor['k_psi'] * subGoal.weight()
                 )
                 self._planner.addForcingGeometry(dm_psi, lag_psi, geo_psi, goalVelocity=goalSymbolicTraj.xdot())
             else:
@@ -184,7 +158,7 @@ class FabricPlanner(Planner):
                     self._q, self._qdot, subGoal.position(), fk
                 )
                 geo_psi = GoalGeometry(
-                    x_psi, xdot_psi, k_psi=self.configAttractor()["k_psi"] * subGoal.weight()
+                    x_psi, xdot_psi, k_psi=self.config.attractor["k_psi"] * subGoal.weight()
                 )
                 self._planner.addForcingGeometry(dm_psi, lag_psi, geo_psi)
             if subGoal.isPrimeGoal():
@@ -198,14 +172,14 @@ class FabricPlanner(Planner):
         self._planner.setExecutionEnergy(exLag)
         # Speed control
         # self._planner.setConstantSpeedControl(beta=2.0)
-        ex_factor = self.configSpeed()["ex_factor"]
+        ex_factor = self.config.speed["ex_factor"]
         self._planner.setDefaultSpeedControl(
             self._x_psi,
             self._dm_psi,
             exLag,
             ex_factor,
-            r_b=self.configDamper()["r_d"],
-            b=self.configDamper()["b"],
+            r_b=self.config.damper["r_d"],
+            b=self.config.damper["b"],
         )
         self._planner.concretize()
 

--- a/plannerbenchmark/planner/pdPlanner.py
+++ b/plannerbenchmark/planner/pdPlanner.py
@@ -1,28 +1,22 @@
+from dataclasses import dataclass
 import numpy as np
 
-from plannerbenchmark.generic.planner import Planner
+from plannerbenchmark.generic.planner import Planner, PlannerConfig
+
+@dataclass
+class PdConfig(PlannerConfig):
+    k: float = 0.8
+    p: float = 0.2
 
 
 class PDPlanner(Planner):
-    def __init__(self, exp, setupFile):
-        required_keys = ["type", "n", 'k', 'p']
-        super().__init__(exp, setupFile, required_keys)
-        self._curError = np.zeros(self.n())
-
-    def interval(self):
-        return 1
-
-    def n(self):
-        return self._setup['n']
+    def __init__(self, exp, **kwargs):
+        super().__init__(exp, **kwargs)
+        self._config = PdConfig(**kwargs)
+        self._curError = np.zeros(self.config.n)
 
     def dt(self):
         return self._exp.dt()
-
-    def k(self):
-        return self._setup['k']
-
-    def p(self):
-        return self._setup['p']
 
     def reset(self):
         pass
@@ -50,5 +44,5 @@ class PDPlanner(Planner):
 
     def computeAction(self, *args):
         self.evalError(args[0])
-        return self.p() * self._curError + self.k() * self._curErrorDot
+        return self.config.p * self._curError + self.config.k * self._curErrorDot
 

--- a/plannerbenchmark/tests/cases/pdplanner_pointMass/default_result/planner.yaml
+++ b/plannerbenchmark/tests/cases/pdplanner_pointMass/default_result/planner.yaml
@@ -2,5 +2,5 @@ k: 0.8
 n: 2
 p: 0.2
 robot_type: pointRobot
-type: pd
+name: pd
 interval: 1

--- a/plannerbenchmark/tests/cases/pdplanner_pointMass/setup/planner.yaml
+++ b/plannerbenchmark/tests/cases/pdplanner_pointMass/setup/planner.yaml
@@ -1,4 +1,4 @@
-type: pd
+name: pd
 interval: 1
 robot_type: pointRobot
 n: 2

--- a/plannerbenchmark/tests/cases/pdplanner_pointMass_2/default_result/planner.yaml
+++ b/plannerbenchmark/tests/cases/pdplanner_pointMass_2/default_result/planner.yaml
@@ -2,5 +2,5 @@ k: 1.8
 n: 2
 p: 0.2
 robot_type: pointRobot
-type: pd
+name: pd
 interval: 1

--- a/plannerbenchmark/tests/cases/pdplanner_pointMass_2/setup/planner.yaml
+++ b/plannerbenchmark/tests/cases/pdplanner_pointMass_2/setup/planner.yaml
@@ -1,4 +1,4 @@
-type: pd
+name: pd
 interval: 1
 robot_type: pointRobot
 n: 2

--- a/plannerbenchmark/tests/local_cases/fabric_panda/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_panda/default_result/planner.yaml
@@ -11,6 +11,7 @@ limits:
   exp: 1.0
   lam: 1.0
 m_base: 1.0
+m_ratio: 1.0
 n: 7
 obst:
   exp: 1.0
@@ -21,4 +22,4 @@ selfCol:
   lam: 2.0
 speed:
   ex_factor: 1.0
-type: fabric
+name: fabric

--- a/plannerbenchmark/tests/local_cases/fabric_panda/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_panda/setup/planner.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/plannerbenchmark/tests/local_cases/fabric_panda_dynamic/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_panda_dynamic/default_result/planner.yaml
@@ -11,6 +11,7 @@ limits:
   exp: 1.0
   lam: 1.0
 m_base: 1.0
+m_ratio: 1.0
 n: 7
 obst:
   exp: 2.0
@@ -21,4 +22,4 @@ selfCol:
   lam: 1.5
 speed:
   ex_factor: 1.0
-type: dynamicFabric
+name: dynamicFabric

--- a/plannerbenchmark/tests/local_cases/fabric_panda_dynamic/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_panda_dynamic/setup/planner.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: dynamicFabric
+name: dynamicFabric
 robot_type: simPanda
 n: 7
 m_base: 1.0

--- a/plannerbenchmark/tests/local_cases/fabric_planarArm/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_planarArm/default_result/planner.yaml
@@ -11,6 +11,7 @@ limits:
   exp: 1.0
   lam: 1.0
 m_base: 1.0
+m_ratio: 1.0
 n: 5
 obst:
   exp: 1.0
@@ -21,4 +22,4 @@ selfCol:
   lam: 2.0
 speed:
   ex_factor: 2.0
-type: fabric
+name: fabric

--- a/plannerbenchmark/tests/local_cases/fabric_planarArm/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_planarArm/setup/planner.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: planarArm
 n: 5
 m_base: 1.0

--- a/plannerbenchmark/tests/local_cases/fabric_pointMass/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_pointMass/default_result/planner.yaml
@@ -11,6 +11,7 @@ limits:
   exp: 3.0
   lam: 10.0
 m_base: 0.2
+m_ratio: 1.0
 n: 2
 obst:
   exp: 1.0
@@ -21,4 +22,4 @@ selfCol:
   lam: 2.0
 speed:
   ex_factor: 1.0
-type: fabric
+name: fabric

--- a/plannerbenchmark/tests/local_cases/fabric_pointMass/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/fabric_pointMass/setup/planner.yaml
@@ -1,5 +1,5 @@
 interval: 1
-type: fabric
+name: fabric
 robot_type: pointRobot
 n: 2
 m_base: 0.2

--- a/plannerbenchmark/tests/local_cases/mpc_panda/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_panda/default_result/planner.yaml
@@ -5,9 +5,11 @@ n: 7
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0
   wvel: 5.0
   wx: 10.0
+robot_type: panda
+dynamic: false

--- a/plannerbenchmark/tests/local_cases/mpc_panda/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_panda/setup/planner.yaml
@@ -5,9 +5,10 @@ n: 7
 obst:
   nbObst: 5
 slack: true
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0
   wvel: 5.0
   wx: 10.0
+robot_type: panda

--- a/plannerbenchmark/tests/local_cases/mpc_planarArm/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_planarArm/default_result/planner.yaml
@@ -5,9 +5,11 @@ n: 5
 obst:
   nbObst: 5
 slack: false
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 5.0
   wvel: 5.0
   wx: 1.0
+robot_type: planarArm
+dynamic: false

--- a/plannerbenchmark/tests/local_cases/mpc_planarArm/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_planarArm/setup/planner.yaml
@@ -1,4 +1,4 @@
-type: mpc
+name: mpc
 n: 5
 dt: 0.5
 H: 30
@@ -11,3 +11,4 @@ weights:
 obst:
   nbObst: 5
 slack: false
+robot_type: planarArm

--- a/plannerbenchmark/tests/local_cases/mpc_pointMass/default_result/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_pointMass/default_result/planner.yaml
@@ -5,9 +5,11 @@ n: 2
 obst:
   nbObst: 5
 slack: false
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 1.0
   wvel: 1.0
   wx: 1.0
+robot_type: pointRobot
+dynamic: false

--- a/plannerbenchmark/tests/local_cases/mpc_pointMass/setup/planner.yaml
+++ b/plannerbenchmark/tests/local_cases/mpc_pointMass/setup/planner.yaml
@@ -4,10 +4,11 @@ interval: 2
 n: 2
 obst:
   nbObst: 5
-type: mpc
+name: mpc
 weights:
   ws: 1e10
   wu: 1.0
   wvel: 1.0
   wx: 1.0
 slack: false
+robot_type: pointRobot


### PR DESCRIPTION
Introduces dataclasses for configuration files for the planners.
The yaml files are parsed in the PlannerRegistry.create_planner function.
That isolates the parsing and abstracts the planners.
Also, it removes several setter functions from the planner.