### PR TITLE
Listen to environment variable to load planners from custom paths

### DIFF
--- a/plannerbenchmark/exec/runner.py
+++ b/plannerbenchmark/exec/runner.py
@@ -12,16 +12,10 @@ from plannerbenchmark.generic.experiment import Experiment, ExperimentInfeasible
 from plannerbenchmark.generic.logger import Logger
 
 from plannerbenchmark.generic.planner  import PlannerRegistry
+from plannerbenchmark.generic.utils import import_custom_planners
+import_custom_planners()
+import plannerbenchmark.planner
 
-# Import different planners
-try:
-    from plannerbenchmark.planner.fabricPlanner import FabricPlanner
-except Exception as e:
-    logging.warning(f"The fabrics mpc planner cannot be used, {e}")
-try:
-    from plannerbenchmark.planner.mpcPlanner import MPCPlanner
-except Exception as e:
-    logging.warning(f"The forces-pro mpc planner cannot be used, {e}")
 
 log_levels = {"WARNING": 30, "INFO": 20, "DEBUG": 10, "QUIET": 100}
 

--- a/plannerbenchmark/generic/utils.py
+++ b/plannerbenchmark/generic/utils.py
@@ -1,0 +1,19 @@
+import os
+import logging
+
+# Import custom planners
+def import_custom_planners():
+    paths = os.environ.get('LOCAL_PLANNER_BENCH_CUSTOM')
+    if paths is None:
+        logging.warn("Environment variable for custom planner directories not set")
+        return
+
+    paths = paths.split(":")
+
+    import importlib.util
+    import sys
+    for i, path in enumerate(paths):
+        spec = importlib.util.spec_from_file_location(f"customPlanners{i}", f"{path}/__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module 
+        spec.loader.exec_module(module)


### PR DESCRIPTION
This PR is related to #48. 

I'm using an environment variable named `LOCAL_PLANNER_BENCH_CUSTOM` to specify a list of paths that contain python modules of custom planners.

Environment variables could be a neat way to tell localPlannerBench about these paths, without having to add an argument every time you execute the `runner`.

Let's say you have a directory with the following path `/home/linus/my_custom_planners`.
The directory should look like:
```
my_custom_planners
    ├── my_planner_1.py
    ├── my_planner_2.py
    ├── ....            
    └── __init__.py
```
Where `__init__.py` should look like:
```python3
from .my_planner_1 import MyPlanner1
from .my_planner_2 import MyPlanner2
```

When this path is added to the environment variable, the `runner` script will look for the `__init__.py` and import/register the custom planners.

Let me know what you think of this approach.

